### PR TITLE
Update config.ocio

### DIFF
--- a/PBR_Neutral/README.md
+++ b/PBR_Neutral/README.md
@@ -6,7 +6,17 @@ For details on how this tone mapper was developed and what problems it solves, p
 - **pbrNeutral.cube** the LUT referenced by config.ocio.
 - **lut-writer.mjs** a script for generating the pbrNeutral.cube LUT and verifying the analytical inverse function.
 
-Currently this tone mapper only supports output to sRGB, but the goal is to expand that in the future. This tone mapper does not apply any gamut mapping, as it is assumed the PBR workflow uses Rec. 709 gamut for both input color textures and lighting (as in glTF), and thus the linear output is already contained within Rec. 709. 
+Currently this tone mapper only supports output to sRGB (two flavors), but the goal is to expand that in the future. This tone mapper does not apply any gamut mapping, as it is assumed the PBR workflow uses Rec. 709 gamut for both input color textures and lighting (as in glTF), and thus the linear output is already contained within Rec. 709. 
+
+## OpenColorIO
+
+The included OCIO configuration makes it easy to use PBR Neutral tone mapping in your existing workflows before they have adopted it natively. Most popular 3D artist tools have a way to supply a custom OpenColorIO config, where you can insert ours. 
+
+Example documentation: 
+
+- [3ds Max](https://help.autodesk.com/view/3DSMAX/2025/ENU/?guid=GUID-DA8CE2F5-1400-45A9-BFCF-A4A8968175CF)
+- [Maya](https://help.autodesk.com/view/MAYAUL/2025/ENU/?guid=GUID-A5A2B5C8-7992-41E3-8482-9DD86EC89717)
+- [Substance Painter](https://helpx.adobe.com/substance-3d-painter/features/color-management/color-management-with-opencolorio.html)
 
 ## PBR Neutral Specification
 
@@ -38,4 +48,4 @@ Notes regarding these equations:
 - $\mathbf c_{out}=\mathbf c_{in}-F_{90}$ for all input colors where $0.08\leq R\leq 0.8$, $0.08\leq G\leq 0.8$, and $0.08\leq B\leq 0.8$. This gives the range of base colors for which the guarantee holds that the base color will be exactly reproduced in the output render for a shiny dielectric material facing the camera under unitary-white lighting. 
 - For all input colors, there are no hue shifts (angle around the white axis), as the only changes are within the plane defined by the input color and the white axis ($[1, 1, 1]$).
 - All partial derivatives of $\mathbf c_{out}$ with respect to $\mathbf c_{in}$ are continuous over the entire domain, vanishing at the boundaries, which is what reduces visual artifacts.
-- This mapping is 1:1 and onto, and analytically invertible. 
+- This mapping is 1:1 and analytically invertible. 

--- a/PBR_Neutral/config.ocio
+++ b/PBR_Neutral/config.ocio
@@ -28,8 +28,12 @@ roles:
 displays:
   sRGB:
     - !<View> {name: PBR Neutral, colorspace: PBR Neutral sRGB}
-active_displays: [sRGB]
+  Gamma 2.2 Rec.709:
+    - !<View> {name: PBR Neutral, colorspace: PBR Neutral Gamma 2.2}
+
+active_displays: [sRGB, Gamma 2.2 Rec.709]
 active_views: [PBR Neutral]
+inactive_colorspaces: [PBR Neutral sRGB, PBR Neutral Gamma 2.2]
 
 colorspaces:
   - !<ColorSpace>

--- a/PBR_Neutral/config.ocio
+++ b/PBR_Neutral/config.ocio
@@ -1,6 +1,8 @@
 
 ocio_profile_version: 2
 
+search_path: .
+
 roles:
   reference: Linear Rec.709
 
@@ -20,19 +22,8 @@ roles:
   # Distribution of colors in color picker
   color_picking: sRGB
 
-  # Non-color data
-  data: Non-Color
-
-  # For interop between configs, and to determine XYZ for rendering
-  aces_interchange: ACES2065-1
-  cie_xyz_d65_interchange: Linear CIE-XYZ D65
-
   # Specified by OCIO
-  color_timing: Linear Rec.709
-  compositing_log: Linear Rec.709
   default: Linear Rec.709
-  matte_paint: Linear Rec.709
-  texture_paint: Linear Rec.709
 
 displays:
   sRGB:
@@ -63,6 +54,18 @@ colorspaces:
         - !<ExponentWithLinearTransform> {gamma: 2.4, offset: 0.055, direction: inverse}
 
   - !<ColorSpace>
+    name: Gamma 2.2 Rec.709
+    family: Display
+    equalitygroup:
+    bitdepth: 32f
+    description: |
+      Pure power sRGB alternative
+    isdata: false
+    from_scene_reference: !<GroupTransform>
+      children:
+        - !<ExponentTransform> {value: 2.2, direction: inverse}
+
+  - !<ColorSpace>
     name: PBR Neutral sRGB
     family: PBR Neutral
     equalitygroup:
@@ -75,3 +78,17 @@ colorspaces:
         - !<AllocationTransform> {allocation: lg2, vars: [-9, 10]}
         - !<FileTransform> {src: pbrNeutral.cube, interpolation: tetrahedral}
         - !<ColorSpaceTransform> {src: Linear Rec.709, dst: sRGB}
+
+  - !<ColorSpace>
+    name: PBR Neutral Gamma 2.2
+    family: PBR Neutral
+    equalitygroup:
+    bitdepth: 32f
+    description: |
+      Khronos PBR Neutral Image Encoding for Gamma 2.2 sRGB Display variant
+    isdata: false
+    from_scene_reference: !<GroupTransform>
+      children:
+        - !<AllocationTransform> {allocation: lg2, vars: [-9, 10]}
+        - !<FileTransform> {src: pbrNeutral.cube, interpolation: tetrahedral}
+        - !<ColorSpaceTransform> {src: Linear Rec.709, dst: Gamma 2.2 Rec.709}


### PR DESCRIPTION
Fixes #1 

Also, now our config.ocio passes validation, which it wasn't before. At the recommendation of an OCIO contributor, rather than updating our definition of sRGB (since technically we already have the officially-standardized one), instead I'm adding a `Gamma 2.2 Rec.709` color space, which has precedent for disambiguating these two versions of sRGB. 